### PR TITLE
security: Avoid leaking exception messages in PIR route responses

### DIFF
--- a/src/pir_sensor/routes.py
+++ b/src/pir_sensor/routes.py
@@ -102,7 +102,10 @@ def start_monitoring():
             )
     except Exception as e:
         logging.error(f"Error starting PIR monitoring: {e}")
-        return jsonify({"success": False, "message": str(e)}), 500
+        return (
+            jsonify({"success": False, "message": "Failed to start PIR monitoring"}),
+            500,
+        )
 
 
 @pir_bp.route("/stop", methods=["POST"])
@@ -113,7 +116,10 @@ def stop_monitoring():
         return jsonify({"success": True, "message": "PIR monitoring stopped"})
     except Exception as e:
         logging.error(f"Error stopping PIR monitoring: {e}")
-        return jsonify({"success": False, "message": str(e)}), 500
+        return (
+            jsonify({"success": False, "message": "Failed to stop PIR monitoring"}),
+            500,
+        )
 
 
 @pir_bp.route("/events")
@@ -152,7 +158,10 @@ def trigger_test_motion():
         return jsonify({"success": True, "message": "Test motion triggered"})
     except Exception as e:
         logging.error(f"Error triggering test motion: {e}")
-        return jsonify({"success": False, "message": str(e)}), 500
+        return (
+            jsonify({"success": False, "message": "Failed to trigger test motion"}),
+            500,
+        )
 
 
 @pir_bp.route("/diagnostics", methods=["GET"])
@@ -165,4 +174,4 @@ def run_diagnostics():
         return jsonify(results)
     except Exception as e:
         logging.error(f"Error running PIR diagnostics: {e}")
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "Failed to run PIR diagnostics"}), 500


### PR DESCRIPTION
## Summary
Fixes CodeQL \`py/stack-trace-exposure\` alerts (#63, #65) on \`src/pir_sensor/routes.py\` by replacing raw \`str(e)\` payloads in JSON responses with generic error strings. Full exception detail is still captured server-side via \`logging.error\`.

Also fixes the same pattern at lines 104 and 115 (\`start_monitoring\`, \`stop_monitoring\`) that CodeQL had not yet flagged — consistency.

## Alerts addressed
- **#63** — \`trigger_test_motion\` (line 155)
- **#65** — \`run_diagnostics\` except block (line 168)
- Plus \`start_monitoring\` (line 104) and \`stop_monitoring\` (line 115)

## Not addressed here
- **#64** — \`run_diagnostics\` success path (line 165). The taint flows through \`run_all_checks()\` in \`diagnostics.py\`, which intentionally embeds error detail in its return value because the whole point of the endpoint is to report hardware diagnostics. To be dismissed as "won't fix" with justification: the app runs on a local network on a Raspberry Pi, not internet-exposed, and diagnostic detail is the intended output.

## Test plan
- [ ] CI
- [ ] Manual: hit \`/pir/start\`, \`/pir/stop\`, \`/pir/trigger_test\`, \`/pir/diagnostics\` while forcing an error and confirm no stack-trace-ish strings in the JSON response

🤖 Generated with [Claude Code](https://claude.com/claude-code)