### PR TITLE
fix(deps): constrain click to patched 8.3.3+ (command injection)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,14 @@ dev = [
 # - cryptography (via google-auth-oauthlib): vulnerable OpenSSL bundled in wheels (<48.0.1)
 # - msgpack (via requests-cache): out-of-bounds read / crash on Unpacker reuse (<=1.2.0)
 # - pip (via pip-audit -> pip-api): path traversal via entry point names (<26.1.2)
+# - click (via black/flask): command injection in click.edit() (<8.3.3); not
+#   reachable from this codebase, constrained to keep pip-audit clean
 constraint-dependencies = [
     "pyasn1>=0.6.3",
     "cryptography>=48.0.1",
     "msgpack>=1.2.1",
     "pip>=26.1.2",
+    "click>=8.3.3",
 ]
 
 [tool.black]

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ resolution-markers = [
 
 [manifest]
 constraints = [
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "pip", specifier = ">=26.1.2" },
@@ -438,14 +439,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Clears the last outstanding `pip-audit` finding. Follow-up to #62, which noted this one and deliberately left it.

**click 8.3.2 → 8.4.2** — PYSEC-2026-2132: command injection via `click.edit()`, allowing arbitrary OS commands to be passed from an unprivileged account. Fixed in 8.3.3; the resolver takes 8.4.2 as the newest release satisfying the constraint.

## Why, given it isn't reachable

This codebase never calls `click.edit()`, so the flaw is **not exploitable here** — that is why #62 left it alone. Constraining it anyway is about signal: `pip-audit` now reports a clean tree, so the next genuine finding shows up against an empty baseline instead of being lost in known, accepted noise.

click arrives transitively via `black` and `flask`, so it is pinned through the existing `[tool.uv] constraint-dependencies` list alongside `pyasn1`, `cryptography`, `msgpack` and `pip`.

## Verification

click 8.4 is a *minor* bump, and both Flask and Black drive their CLIs through click, so the blast radius was checked rather than assumed:

- `flask --version` works (Flask 3.1.3 / Werkzeug 3.1.8).
- `black --version` works.
- `create_app()` builds cleanly — 36 routes registered.
- `uv lock --check` passes; ruff and `black --check` clean; 235 tests pass.
- **`pip-audit`: `No known vulnerabilities found`** — clean for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)