### PR TITLE
ci(security): make the security workflow fail on findings

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -143,14 +143,16 @@ jobs:
   docker-scan:
     runs-on: ubuntu-latest
     name: Container Security (if applicable)
-    # hashFiles is empty when no Dockerfile exists. The previous condition tested the
-    # repository *name* for the string "Dockerfile", so this job could never run.
-    if: hashFiles('Dockerfile') != ''
 
     steps:
     - uses: actions/checkout@v7
 
+    # The steps are guarded rather than the job: hashFiles is only available in a
+    # step context, and it needs the repo checked out to see the file anyway. The
+    # previous job-level condition tested the repository *name* for the string
+    # "Dockerfile", so this job could never do anything.
     - name: Run Trivy vulnerability scanner
+      if: hashFiles('Dockerfile') != ''
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'fs'
@@ -161,8 +163,8 @@ jobs:
         severity: 'CRITICAL,HIGH'
 
     - name: Upload Trivy results to GitHub Security tab
+      if: hashFiles('Dockerfile') != ''
       uses: github/codeql-action/upload-sarif@v4
-      if: always()
       with:
         sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,12 +35,13 @@ jobs:
         uv venv
         uv pip install -e .
 
+    # Writes the report for the artifact, then re-runs to gate. The first run is
+    # allowed to fail so a finding still produces an uploadable report.
     - name: Run pip-audit
       run: |
         uv pip install pip-audit
-        uv run pip-audit --desc --format json --output audit-report.json 2>/dev/null || echo '{"vulnerabilities": []}' > audit-report.json
-        uv run pip-audit --desc || true
-      continue-on-error: true
+        uv run pip-audit --desc --format json --output audit-report.json || true
+        uv run pip-audit --desc
 
     - name: Upload pip-audit results
       uses: actions/upload-artifact@v7
@@ -48,21 +49,6 @@ jobs:
       with:
         name: pip-audit-results
         path: audit-report.json
-        if-no-files-found: ignore
-
-    - name: Run Safety check
-      run: |
-        uv pip install safety
-        uv run safety check --json --output safety-report.json 2>/dev/null || echo '{"vulnerabilities": []}' > safety-report.json
-        uv run safety check || true
-      continue-on-error: true
-
-    - name: Upload Safety results
-      uses: actions/upload-artifact@v7
-      if: always()
-      with:
-        name: safety-results
-        path: safety-report.json
         if-no-files-found: ignore
 
   code-security:
@@ -81,11 +67,12 @@ jobs:
       run: |
         pip install bandit[toml] semgrep
 
+    # Gates on medium-and-above findings. B101 (assert) is skipped because pytest
+    # relies on bare asserts.
     - name: Run Bandit security linter
       run: |
         bandit -r src -f json -o bandit-report.json -ll --skip B101 || true
         bandit -r src -ll --skip B101
-      continue-on-error: true
 
     - name: Upload Bandit results
       uses: actions/upload-artifact@v7
@@ -94,15 +81,16 @@ jobs:
         name: bandit-results
         path: bandit-report.json
 
+    # --error makes semgrep exit non-zero on any finding. Known false positives are
+    # suppressed at the source with `# nosemgrep: <rule-id>` plus a justification.
     - name: Run Semgrep
-      uses: returntocorp/semgrep-action@v1
-      with:
-        config: >-
-          p/security-audit
-          p/python
-          p/flask
-          p/owasp-top-ten
-      continue-on-error: true
+      run: |
+        semgrep scan --error --quiet \
+          --config p/security-audit \
+          --config p/python \
+          --config p/flask \
+          --config p/owasp-top-ten \
+          src
 
   secret-scanning:
     runs-on: ubuntu-latest
@@ -113,20 +101,21 @@ jobs:
       with:
         fetch-depth: 0  # Full history for better secret detection
 
+    # Fails only on verified live credentials, so this does not fire on placeholders.
     - name: TruffleHog OSS
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
         base: ${{ github.event.repository.default_branch }}
-        extra_args: --debug --only-verified
-      continue-on-error: true
+        extra_args: --only-verified
 
+    # Fails on any secret not already recorded in .secrets.baseline. To accept a new
+    # false positive, re-run `detect-secrets scan --baseline .secrets.baseline` and
+    # commit the updated baseline.
     - name: Detect secrets with detect-secrets
       run: |
         pip install detect-secrets
-        detect-secrets scan --baseline .secrets.baseline || true
-        detect-secrets audit .secrets.baseline || true
-      continue-on-error: true
+        detect-secrets-hook --baseline .secrets.baseline $(git ls-files)
 
   codeql-analysis:
     runs-on: ubuntu-latest
@@ -154,7 +143,9 @@ jobs:
   docker-scan:
     runs-on: ubuntu-latest
     name: Container Security (if applicable)
-    if: contains(github.repository, 'Dockerfile')
+    # hashFiles is empty when no Dockerfile exists. The previous condition tested the
+    # repository *name* for the string "Dockerfile", so this job could never run.
+    if: hashFiles('Dockerfile') != ''
 
     steps:
     - uses: actions/checkout@v7
@@ -166,7 +157,8 @@ jobs:
         scan-ref: '.'
         format: 'sarif'
         output: 'trivy-results.sarif'
-      continue-on-error: true
+        exit-code: '1'
+        severity: 'CRITICAL,HIGH'
 
     - name: Upload Trivy results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v4

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -111,6 +111,34 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
-  "results": {},
-  "generated_at": "2025-01-13T00:00:00Z"
+  "results": {
+    "config.default.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "config.default.json",
+        "hashed_secret": "cc3536ff7fea851effd9c9c5072097543b93cac0",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "tests/photo_upload/test_auth.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/photo_upload/test_auth.py",
+        "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "tests/test_config.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_config.py",
+        "hashed_secret": "954abcc2a4e3d5abd3e8e13383907a29811b1098",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ]
+  },
+  "generated_at": "2026-07-13T15:32:22Z"
 }

--- a/src/google_integration/api.py
+++ b/src/google_integration/api.py
@@ -114,11 +114,13 @@ def authenticate_calendar():
             try:
                 creds.refresh(Request())
             except Exception as e:
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs the exception, not credential material
                 logger.error("Error refreshing calendar token: %s", e)
                 creds = None
 
         if not creds:
             if not os.path.exists(creds_path):
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a filesystem path, not credential material
                 logger.error("Credentials file not found at %s", creds_path)
                 return None
             try:
@@ -135,6 +137,7 @@ def authenticate_calendar():
                 with open(token_path, "w") as token:
                     token.write(creds.to_json())
             except IOError as e:
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs the exception, not credential material
                 logger.error("Error saving calendar token file: %s", e)
 
     return creds

--- a/src/google_integration/tasks_api.py
+++ b/src/google_integration/tasks_api.py
@@ -43,11 +43,13 @@ def authenticate_tasks():
             try:
                 creds.refresh(Request())
             except Exception as e:
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs the exception, not credential material
                 logger.error("Error refreshing tasks token: %s", e)
                 creds = None
 
         if not creds:
             if not os.path.exists(creds_path):
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs a filesystem path, not credential material
                 logger.error("Credentials file not found at %s", creds_path)
                 return None
             try:
@@ -64,6 +66,7 @@ def authenticate_tasks():
                 with open(token_path, "w") as token:
                     token.write(creds.to_json())
             except IOError as e:
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure -- logs the exception, not credential material
                 logger.error("Error saving tasks token file: %s", e)
 
     return creds

--- a/src/health_monitor.py
+++ b/src/health_monitor.py
@@ -244,8 +244,11 @@ class HealthMonitor:
         except (FileNotFoundError, subprocess.TimeoutExpired) as e:
             logger.warning("Systemd not available for restart: %s", e)
 
-        # Fallback: restart the Python process directly
+        # Fallback: restart the Python process directly.
+        # Re-execs this same interpreter with its own argv; argv comes from the service
+        # definition, never from a request.
         logger.info("Falling back to direct process restart")
+        # nosemgrep: python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
         os.execv(sys.executable, [sys.executable] + sys.argv)
 
     def enable_monitoring(self):

--- a/src/photo_upload/routes.py
+++ b/src/photo_upload/routes.py
@@ -464,7 +464,10 @@ def generate_qrcode():
         token = token_data["token"]
         expiry = token_data["expiry"]
 
-        # Create the URL with embedded token
+        # Create the URL with embedded token.
+        # host is resolved by get_local_ip() or CALENDAR_UPLOAD_HOST, never from the
+        # request's Host header, and the URL is only encoded into a QR image, not fetched.
+        # nosemgrep: python.flask.security.injection.tainted-url-host.tainted-url-host
         base_url = f"http://{host}:{port}/upload/manage"
         upload_url = generate_upload_url(base_url, token)
 


### PR DESCRIPTION
## The problem

Every scanner in `security.yml` was wrapped in **both** `|| true` **and** `continue-on-error: true`. The job reported success no matter what the scanners found — a green badge meant only that they had run, not that they found nothing.

This was not theoretical. The pip path traversal fixed in #62 was being reported by pip-audit while the workflow stayed green, and it arrived through **pip-audit's own dependency chain** (`pip-audit` → `pip-api` → `pip`).

## What changed

Scanners now gate on their exit codes: **pip-audit**, **Bandit** (medium+, `B101` skipped for pytest's bare asserts), **Semgrep** (`--error`), **TruffleHog** (verified secrets only), **detect-secrets**. CodeQL and Dependency Review already gated.

The report-generating pip-audit and Bandit runs keep `|| true` so a finding still produces an uploadable artifact; the gating re-run follows.

Three cleanups fell out of this:

- **Dropped Safety.** `safety check` was deprecated in June 2024 and now requires an authenticated account, so it has been a silent no-op. It is redundant with pip-audit, and its own dependency tree (`authlib`, `nltk`) was contributing vulnerability noise.
- **Replaced `returntocorp/semgrep-action@v1`** (archived) with the maintained CLI.
- **Fixed the container job's condition.** `contains(github.repository, 'Dockerfile')` tested the repository *name* for the string "Dockerfile", so the job could never run. Now `hashFiles('Dockerfile') != ''`, with Trivy gating on CRITICAL/HIGH.

## Baseline was verified clean first, so `main` stays green

Flipping these gates on a dirty tree would turn `main` red immediately, so I triaged everything first.

**Semgrep reported 8 findings — all false positives.** Suppressed at the source with `# nosemgrep: <rule-id>` plus a justification, rather than disabling the rules globally, so a genuine hit elsewhere is still caught:

| Finding | Why it's a false positive |
|---|---|
| `python-logger-credential-disclosure` ×6 | Fires on message *text* ("token", "Credentials"); only the exception object or a file path is ever logged |
| `dangerous-os-exec-tainted-env-args` | `os.execv` in the health monitor's self-restart; `argv` comes from the service definition, never a request |
| `tainted-url-host` | `host` comes from `get_local_ip()` or `CALENDAR_UPLOAD_HOST`, never the `Host` header; the URL is only encoded into a QR image, not fetched |

**`.secrets.baseline` had an empty `results` set** — detect-secrets was scanning against nothing, which is why it always passed. Repopulated with the three findings, each confirmed benign: a placeholder in `config.default.json` (the real `config.json` is gitignored) and two test fixtures.

## Verification

- All gating steps pass on a clean tree — pip-audit, Bandit, Semgrep, detect-secrets — so this merges green.
- **Negative test:** introduced a `subprocess.call(cmd, shell=True)` and confirmed both Bandit (B602, High) and Semgrep exit non-zero. The gates genuinely fire.
- 235 tests, ruff and black all pass.

## Note for future false positives

- **Semgrep:** add `# nosemgrep: <rule-id>` on the line directly above the finding, with a reason. It must be immediately adjacent — an intervening comment line breaks it.
- **detect-secrets:** re-run `detect-secrets scan --baseline .secrets.baseline` and commit the updated baseline.
- **Bandit:** note that `# nosec` is matched as a *substring*, so any comment containing that text (even `# nosec-free`) will silence the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)