### PR TITLE
ci: gate on uv.lock drift and stop ignoring .github/ and uv.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v7
 
+    # Dependabot bumps version floors in pyproject.toml without re-locking, which can
+    # leave uv.lock pinned below its own declared minimums. Nothing else catches that:
+    # the install steps resolve fresh rather than installing from the lock.
+    - name: Verify uv.lock is in sync with pyproject.toml
+      run: uv lock --check
+
     - name: Install dependencies
       run: |
         uv venv

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ reports/
 # Generated files that change frequently
 calendar.log
 src/weather_integration/weather_cache.json
-uv.lock
 
-.github/
+# uv.lock and .github/ were listed here but are both tracked, so the entries never
+# took effect. They are deliberately committed: the lockfile pins the exact
+# dependency versions we ship and audit, and .github/ holds the CI workflows. Left
+# in place they were a trap -- a new workflow file would be silently skipped by
+# `git add`, and dropping uv.lock from the index would make it disappear unnoticed.


### PR DESCRIPTION
## `.gitignore` had two entries that never took effect

It listed both `uv.lock` and `.github/`. Neither did anything, because both are tracked — but left in place they were traps:

- A **new** workflow file would be silently skipped by `git add`. This actually bit me while fixing `security.yml` in #64.
- Dropping `uv.lock` from the index would make the lockfile disappear without anyone noticing.

Both are deliberately committed — the lockfile pins the exact versions we ship and audit, and `.github/` holds the CI workflows — so the entries are removed and the reasoning recorded in a comment.

## CI now gates on lockfile drift

Added `uv lock --check` to the lint job.

Dependabot bumps version floors in `pyproject.toml` **without re-locking**. That recently left `uv.lock` pinned *below* its own declared minimums for `ruff`, `google-api-core` and `google-api-python-client` (cleaned up in #62). Nothing caught it, because the install steps resolve fresh rather than installing from the lock — so CI stayed green while the lockfile was internally inconsistent.

## Verification

- Passes on the current tree.
- **Negative test:** raised a floor (`psutil>=99.0.0`) without re-locking and confirmed `uv lock --check` exits non-zero. It fires on exactly the pattern that slipped through.
- `actionlint` clean across all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)