### PR TITLE
fix(deps): constrain httplib2 to patched 0.32.0 (decompression DoS)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,15 @@ dev = [
 # - pip (via pip-audit -> pip-api): path traversal via entry point names (<26.1.2)
 # - click (via black/flask): command injection in click.edit() (<8.3.3); not
 #   reachable from this codebase, constrained to keep pip-audit clean
+# - httplib2 (via google-auth-httplib2): unbounded decompression of gzip/deflate
+#   response bodies -> memory exhaustion / OOM DoS PYSEC-2026-3444 (<0.32.0)
 constraint-dependencies = [
     "pyasn1>=0.6.3",
     "cryptography>=48.0.1",
     "msgpack>=1.2.1",
     "pip>=26.1.2",
     "click>=8.3.3",
+    "httplib2>=0.32.0",
 ]
 
 [tool.black]

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ resolution-markers = [
 constraints = [
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "httplib2", specifier = ">=0.32.0" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "pip", specifier = ">=26.1.2" },
     { name = "pyasn1", specifier = ">=0.6.3" },
@@ -701,14 +702,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves the failed scheduled **Security Scan** ([run 29385432182](https://github.com/Rasheed-bannister/family_calendar/actions/runs/29385432182)) from the night of 2026-07-15.

`pip-audit` flagged **`PYSEC-2026-3444`** in **httplib2 0.31.2**: unbounded decompression of `gzip`/`deflate` HTTP response bodies. A malicious or compromised server can return a small compressed payload that expands to an arbitrary size in memory, causing `MemoryError` / OOM-kill in the client. Fixed upstream in **0.32.0**.

`httplib2` is a transitive dependency via `google-auth-httplib2` (Google Calendar/Tasks client). No first-party code changed — the advisory was published upstream and the daily scan caught it.

## Change

- Pin `httplib2>=0.32.0` in `[tool.uv] constraint-dependencies`, matching the existing pattern for patched transitive deps (pyasn1, cryptography, msgpack, pip, click).
- `uv lock` regenerated: `httplib2 0.31.2 -> 0.32.0`.

## Verification

`uv run pip-audit --desc` locally now reports **No known vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)